### PR TITLE
Fix plugin structure per Claude Code plugin conventions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,5 +7,7 @@
   },
   "homepage": "https://github.com/taskyou/taskyou-os",
   "repository": "https://github.com/taskyou/taskyou-os",
+  "license": "MIT",
+  "keywords": ["agents", "automation", "taskyou", "remote", "productivity"],
   "commands": "./.claude/commands"
 }

--- a/.claude/commands/launch.md
+++ b/.claude/commands/launch.md
@@ -1,3 +1,8 @@
+---
+name: launch
+description: Launch a new TaskYou-OS General Manager — interactive setup that provisions a server, configures your project, and deploys your AI agent team.
+---
+
 You are a friendly setup assistant. Walk the user through launching a new TaskYou-OS General Manager — their personal AI agent team that runs on a remote server.
 
 User arguments (if any): $ARGUMENTS


### PR DESCRIPTION
Small housekeeping PR based on auditing against `plugin-dev:plugin-structure` best practices.

**Changes:**
- **`launch.md`** — Added YAML frontmatter (`name: launch`, `description: ...`) so the command is properly discovered with metadata
- **`plugin.json`** — Added `license` and `keywords` fields (matches marketplace.json tags)
- **Removed empty `.claude/skills/`** directory

**Not changed (intentionally):**
- Commands path stays at `./.claude/commands` (non-standard but works fine via custom path in plugin.json, and avoids confusion with `templates/commands/` which are GM command templates)