### PR TITLE
Add exe.dev GM deployment support

### DIFF
--- a/config.example.env
+++ b/config.example.env
@@ -64,3 +64,10 @@ PROJECT_DESCRIPTION="My Project does X, Y, and Z."
 # Used for push/merge workflow and documented in CLAUDE.md
 
 # GITHUB_REPOS="content:myorg/content-repo,marketing:myorg/marketing-repo"
+
+# === Optional: exe.dev deployment ===
+# Set EXE_DEV_ENABLED=true to deploy the GM onto an exe.dev VM
+# instead of (or in addition to) a traditional server.
+
+# EXE_DEV_ENABLED="true"
+# EXE_DEV_VM_NAME="myproject-gm"

--- a/setup.sh
+++ b/setup.sh
@@ -18,6 +18,7 @@ usage() {
   echo "Modes:"
   echo "  local   — Generate local GM files only"
   echo "  server  — Provision the remote server only"
+  echo "  exe     — Deploy GM to an exe.dev VM"
   echo "  all     — Both local and server"
   echo ""
   echo "The project-dir must contain a config.env file."
@@ -175,8 +176,8 @@ MODE="$1"
 PROJECT_DIR="$(cd "$2" && pwd 2>/dev/null || echo "$2")"
 CONFIG_FILE="$PROJECT_DIR/config.env"
 
-if [[ "$MODE" != "local" && "$MODE" != "server" && "$MODE" != "all" ]]; then
-  echo "Error: mode must be local, server, or all"
+if [[ "$MODE" != "local" && "$MODE" != "server" && "$MODE" != "exe" && "$MODE" != "all" ]]; then
+  echo "Error: mode must be local, server, exe, or all"
   usage
 fi
 
@@ -192,7 +193,13 @@ fi
 source "$CONFIG_FILE"
 
 # Validate required vars
-for var in PROJECT_NAME PROJECT_DISPLAY_NAME GM_ALIAS SERVER_HOST SERVER_USER SERVER_HOME PROJECTS LOCAL_PROJECT_DIR CLAUDE_CONFIG_DIR GIT_NAME GIT_EMAIL; do
+REQUIRED_VARS="PROJECT_NAME PROJECT_DISPLAY_NAME GM_ALIAS PROJECTS GIT_NAME GIT_EMAIL"
+if [[ "$MODE" == "exe" ]]; then
+  REQUIRED_VARS="$REQUIRED_VARS EXE_DEV_VM_NAME"
+else
+  REQUIRED_VARS="$REQUIRED_VARS SERVER_HOST SERVER_USER SERVER_HOME LOCAL_PROJECT_DIR CLAUDE_CONFIG_DIR"
+fi
+for var in $REQUIRED_VARS; do
   if [[ -z "${!var:-}" ]]; then
     echo "Error: $var is required in config.env"
     exit 1
@@ -201,8 +208,9 @@ done
 
 # Derived variables
 PROJECT_NAME_UPPER=$(echo "$PROJECT_NAME" | tr '[:lower:]' '[:upper:]')
-export PROJECT_NAME PROJECT_DISPLAY_NAME GM_ALIAS SERVER_HOST SERVER_USER SERVER_HOME
-export PROJECTS LOCAL_PROJECT_DIR CLAUDE_CONFIG_DIR GIT_NAME GIT_EMAIL
+export PROJECT_NAME PROJECT_DISPLAY_NAME GM_ALIAS GIT_NAME GIT_EMAIL PROJECTS
+export SERVER_HOST="${SERVER_HOST:-}" SERVER_USER="${SERVER_USER:-}" SERVER_HOME="${SERVER_HOME:-}"
+export LOCAL_PROJECT_DIR="${LOCAL_PROJECT_DIR:-}" CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-}"
 export PROJECT_NAME_UPPER
 export PROJECT_DESCRIPTION="${PROJECT_DESCRIPTION:-}"
 export OWNER_NAME="${OWNER_NAME:-the owner}"
@@ -217,6 +225,8 @@ export R2_ENABLED="${R2_ENABLED:-false}"
 export R2_BUCKET="${R2_BUCKET:-}"
 export R2_PUBLIC_URL="${R2_PUBLIC_URL:-}"
 export GITHUB_REPOS="${GITHUB_REPOS:-}"
+export EXE_DEV_ENABLED="${EXE_DEV_ENABLED:-false}"
+export EXE_DEV_VM_NAME="${EXE_DEV_VM_NAME:-}"
 
 # Generate dynamic table content
 export PROJECTS_TABLE
@@ -516,6 +526,344 @@ EOF
   log "Server setup complete"
 }
 
+# ── exe.dev deployment ────────────────────────────────────────────────────────
+
+setup_exe_dev() {
+  if [[ -z "$EXE_DEV_VM_NAME" ]]; then
+    echo "Error: EXE_DEV_VM_NAME is required for exe.dev deployment"
+    echo "Set it in config.env"
+    exit 1
+  fi
+
+  local EXE_HOST="exedev@${EXE_DEV_VM_NAME}.exe.xyz"
+  local EXE_HOME="/home/exedev"
+
+  log "Deploying GM to exe.dev VM: $EXE_DEV_VM_NAME"
+
+  # Check SSH access to exe.dev management
+  if ! ssh -o ConnectTimeout=5 -o BatchMode=yes exe.dev "echo ok" >/dev/null 2>&1; then
+    echo "Error: Cannot SSH to exe.dev"
+    echo "Make sure your SSH key is registered with exe.dev."
+    echo "Visit https://exe.dev to set up your account and SSH key."
+    exit 1
+  fi
+  ok "exe.dev SSH access"
+
+  # Create or verify VM exists
+  if ssh -o ConnectTimeout=5 -o BatchMode=yes "$EXE_HOST" "echo ok" >/dev/null 2>&1; then
+    ok "VM $EXE_DEV_VM_NAME already exists"
+  else
+    log "Creating exe.dev VM: $EXE_DEV_VM_NAME"
+    ssh exe.dev "vm create $EXE_DEV_VM_NAME" || {
+      echo "Error: Failed to create VM. Create it manually at https://exe.dev"
+      exit 1
+    }
+    # Wait for VM to become available
+    echo "  Waiting for VM to be ready..."
+    for i in $(seq 1 30); do
+      if ssh -o ConnectTimeout=5 -o BatchMode=yes "$EXE_HOST" "echo ok" >/dev/null 2>&1; then
+        break
+      fi
+      sleep 2
+    done
+    ok "VM created"
+  fi
+
+  # Helper to run commands on the exe.dev VM
+  exe_remote() {
+    ssh "$EXE_HOST" "$@"
+  }
+
+  exe_remote_with_path() {
+    ssh "$EXE_HOST" "export PATH=$EXE_HOME/bin:$EXE_HOME/.local/bin:\$PATH && $*"
+  }
+
+  # Install TaskYou
+  if exe_remote "test -f $EXE_HOME/.local/bin/ty" 2>/dev/null; then
+    ok "TaskYou already installed"
+  else
+    log "Installing TaskYou"
+    exe_remote "curl -fsSL https://taskyou.dev/install.sh | bash" || {
+      warn "TaskYou auto-install failed. Install it manually on the VM."
+      exit 1
+    }
+    ok "TaskYou installed"
+  fi
+
+  # Git identity
+  log "Configuring git identity"
+  exe_remote "git config --global user.name '$GIT_NAME' && git config --global user.email '$GIT_EMAIL'"
+  ok "git: $GIT_NAME <$GIT_EMAIL>"
+
+  # Pre-configure Claude Code (skip onboarding)
+  log "Pre-configuring Claude Code"
+  exe_remote 'test -f ~/.claude.json || echo "{\"hasCompletedOnboarding\":true,\"theme\":\"dark\",\"shiftEnterKeyBindingInstalled\":true}" > ~/.claude.json'
+  exe_remote 'mkdir -p ~/.claude && test -f ~/.claude/settings.json || echo "{\"skipDangerousModePermissionPrompt\":true}" > ~/.claude/settings.json'
+  ok "Claude Code onboarding pre-configured"
+
+  # Create project repos
+  log "Creating project repositories"
+  IFS=',' read -ra projs <<< "$PROJECTS"
+  for proj in "${projs[@]}"; do
+    proj=$(echo "$proj" | xargs)
+    local repo_path="$EXE_HOME/projects/$proj"
+    if exe_remote "test -d $repo_path/.git" 2>/dev/null; then
+      ok "$proj (already exists)"
+    else
+      exe_remote "mkdir -p $repo_path && cd $repo_path && git init -q"
+      ok "$proj"
+    fi
+
+    # Write base CLAUDE.md into each project repo
+    local rendered
+    rendered=$(render "$(<"$TEMPLATES_DIR/project-claude-md.tmpl")")
+    ssh "$EXE_HOST" "cat > $repo_path/CLAUDE.md" <<< "$rendered"
+    exe_remote "cd $repo_path && git add CLAUDE.md && git diff --cached --quiet || git commit -q -m 'Add base CLAUDE.md'" 2>/dev/null || true
+
+    # Pre-accept Claude trust
+    ssh "$EXE_HOST" "python3 -c \"
+import json
+cf = '$HOME/.claude.json'
+with open(cf) as f: data = json.load(f)
+p = data.setdefault('projects', {}).setdefault('$repo_path', {})
+p['hasTrustDialogAccepted'] = True
+p['hasCompletedProjectOnboarding'] = True
+with open(cf, 'w') as f: json.dump(data, f, indent=2)
+\""
+    ok "  Claude pre-authorized for $proj"
+
+    # Register project with TaskYou
+    if exe_remote_with_path "ty projects show $proj" >/dev/null 2>&1; then
+      ok "  ty project $proj (already registered)"
+    else
+      exe_remote_with_path "ty projects create $proj --path $repo_path"
+      ok "  ty project $proj registered"
+    fi
+  done
+
+  # GM project directory
+  log "Setting up GM project directory"
+  exe_remote "mkdir -p $EXE_HOME/projects/gm/.claude"
+
+  # Generate server-local CLAUDE.md
+  render_file "$TEMPLATES_DIR/exe-dev/CLAUDE.md.tmpl" "/tmp/taskyou-exe-dev-claude-md"
+  scp -q "/tmp/taskyou-exe-dev-claude-md" "$EXE_HOST:$EXE_HOME/projects/gm/CLAUDE.md"
+  rm -f "/tmp/taskyou-exe-dev-claude-md"
+  ok "GM CLAUDE.md (server-local)"
+
+  # GM .claude/settings.json
+  render_file "$TEMPLATES_DIR/settings.json.tmpl" "/tmp/taskyou-exe-dev-settings"
+  scp -q "/tmp/taskyou-exe-dev-settings" "$EXE_HOST:$EXE_HOME/projects/gm/.claude/settings.json"
+  rm -f "/tmp/taskyou-exe-dev-settings"
+  ok "GM .claude/settings.json"
+
+  # Pre-accept Claude trust for GM directory
+  ssh "$EXE_HOST" "python3 -c \"
+import json
+cf = '$HOME/.claude.json'
+with open(cf) as f: data = json.load(f)
+p = data.setdefault('projects', {}).setdefault('$EXE_HOME/projects/gm', {})
+p['hasTrustDialogAccepted'] = True
+p['hasCompletedProjectOnboarding'] = True
+with open(cf, 'w') as f: json.dump(data, f, indent=2)
+\""
+  ok "Claude pre-authorized for GM"
+
+  # Init git in GM dir if needed
+  exe_remote "cd $EXE_HOME/projects/gm && test -d .git || git init -q"
+  ok "GM git repo"
+
+  # Install TaskYou hooks
+  log "Installing TaskYou hooks"
+  local hooks_dir="$EXE_HOME/.config/task/hooks"
+  exe_remote "mkdir -p $hooks_dir"
+
+  for hook_tmpl in "$TEMPLATES_DIR"/hooks/*.tmpl; do
+    local hook_name
+    hook_name=$(basename "$hook_tmpl" .tmpl)
+    local rendered
+    rendered=$(render "$(<"$hook_tmpl")")
+    ssh "$EXE_HOST" "cat > $hooks_dir/$hook_name && chmod +x $hooks_dir/$hook_name" <<< "$rendered"
+    ok "hook: $hook_name"
+  done
+
+  # Create notifications file
+  exe_remote "touch $EXE_HOME/notifications.jsonl"
+  ok "notifications.jsonl"
+
+  # GM launcher script
+  log "Setting up GM launcher"
+  exe_remote "mkdir -p $EXE_HOME/bin"
+  render_file "$TEMPLATES_DIR/exe-dev/gm-launcher.tmpl" "/tmp/taskyou-exe-dev-gm-launcher"
+  scp -q "/tmp/taskyou-exe-dev-gm-launcher" "$EXE_HOST:$EXE_HOME/bin/gm"
+  exe_remote "chmod +x $EXE_HOME/bin/gm"
+  rm -f "/tmp/taskyou-exe-dev-gm-launcher"
+  ok "bin/gm launcher"
+
+  # Bashrc auto-launch hook (idempotent)
+  log "Setting up bashrc auto-launch hook"
+  local bashrc_marker="# Auto-launch GM for xterm sessions"
+  if exe_remote "grep -q '$bashrc_marker' $EXE_HOME/.bashrc 2>/dev/null"; then
+    ok "bashrc hook (already installed)"
+  else
+    ssh "$EXE_HOST" "cat >> $EXE_HOME/.bashrc" <<'BASHRC_EOF'
+
+# Auto-launch GM for xterm sessions named gm or gm-*
+_parent_cmd=$(cat /proc/$PPID/cmdline 2>/dev/null | tr '\0' ' ')
+if [[ "$_parent_cmd" == *xterm-exe.dev-gm* ]]; then
+  exec gm
+fi
+unset _parent_cmd
+BASHRC_EOF
+    ok "bashrc hook installed"
+  fi
+
+  # Board refresh daemon
+  log "Setting up board refresh daemon"
+  render_file "$TEMPLATES_DIR/exe-dev/board-refresh.tmpl" "/tmp/taskyou-exe-dev-board-refresh"
+  scp -q "/tmp/taskyou-exe-dev-board-refresh" "$EXE_HOST:$EXE_HOME/bin/board-refresh"
+  exe_remote "chmod +x $EXE_HOME/bin/board-refresh"
+  rm -f "/tmp/taskyou-exe-dev-board-refresh"
+  ok "bin/board-refresh"
+
+  # Board refresh crontab (idempotent)
+  local cron_line="@reboot $EXE_HOME/bin/board-refresh"
+  if exe_remote "crontab -l 2>/dev/null" | grep -q "board-refresh"; then
+    ok "board-refresh cron (already installed)"
+  else
+    exe_remote "(crontab -l 2>/dev/null; echo '$cron_line') | crontab -"
+    ok "board-refresh cron installed"
+  fi
+
+  # Start board-refresh now if not running
+  if exe_remote "pgrep -f board-refresh" >/dev/null 2>&1; then
+    ok "board-refresh already running"
+  else
+    exe_remote "nohup $EXE_HOME/bin/board-refresh > /tmp/board-refresh.log 2>&1 &"
+    ok "board-refresh started"
+  fi
+
+  # Landing page
+  log "Setting up landing page"
+  exe_remote "sudo mkdir -p /var/www/html"
+  render_file "$TEMPLATES_DIR/exe-dev/landing-page.html.tmpl" "/tmp/taskyou-exe-dev-landing"
+  scp -q "/tmp/taskyou-exe-dev-landing" "$EXE_HOST:/tmp/taskyou-landing.html"
+  exe_remote "sudo mv /tmp/taskyou-landing.html /var/www/html/index.html"
+  rm -f "/tmp/taskyou-exe-dev-landing"
+  ok "landing page"
+
+  # Nginx
+  log "Setting up nginx"
+  # Ensure nginx serves on port 8000
+  exe_remote "sudo tee /etc/nginx/sites-available/default > /dev/null" <<'NGINX_EOF'
+server {
+    listen 8000 default_server;
+    root /var/www/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+
+    location /board.json {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Access-Control-Allow-Origin "*";
+    }
+}
+NGINX_EOF
+  exe_remote "sudo systemctl start nginx && sudo systemctl enable nginx" 2>/dev/null
+  exe_remote "sudo nginx -t && sudo systemctl reload nginx" 2>/dev/null
+  ok "nginx configured (port 8000)"
+
+  # Set exe.dev proxy to point at port 8000
+  ssh exe.dev "share port $EXE_DEV_VM_NAME 8000" 2>/dev/null || warn "Could not set proxy port. Run: ssh exe.dev share port $EXE_DEV_VM_NAME 8000"
+  ok "exe.dev proxy → port 8000"
+
+  # Set VM to private by default
+  ssh exe.dev "share set-private $EXE_DEV_VM_NAME" 2>/dev/null || true
+  ok "VM access set to private"
+
+  # Linear module (same as server setup)
+  if [[ "$LINEAR_ENABLED" == "true" ]]; then
+    log "Setting up Linear integration"
+
+    local cli_dir="$EXE_HOME/tools/linear-cli"
+    exe_remote "mkdir -p $cli_dir"
+    scp -q "$MODULES_DIR/linear/linear-cli/linear.mjs" "$EXE_HOST:$cli_dir/linear.mjs"
+    exe_remote "chmod +x $cli_dir/linear.mjs"
+
+    local linear_labels_json="{\"agent handoff\":\"$LINEAR_LABEL_ID\"}"
+    local linear_states_json="{\"todo\":\"$LINEAR_STATE_ID\"}"
+    ssh "$EXE_HOST" "cat > $cli_dir/.env" <<EOF
+LINEAR_TOKEN=$LINEAR_API_KEY
+LINEAR_TOKEN_AGENTS=$LINEAR_API_KEY
+LINEAR_TEAM_ID=$LINEAR_TEAM_ID
+LINEAR_TEAM_KEY=$LINEAR_TEAM_KEY
+LINEAR_LABELS=$linear_labels_json
+LINEAR_STATES=$linear_states_json
+EOF
+    ok "Linear CLI installed"
+
+    exe_remote "ln -sf $cli_dir/linear.mjs $EXE_HOME/bin/linear"
+    ok "linear → ~/bin/linear"
+
+    local scripts_dir="$EXE_HOME/scripts"
+    exe_remote "mkdir -p $scripts_dir"
+    scp -q "$MODULES_DIR/linear/linear-poll.mjs" "$EXE_HOST:$scripts_dir/linear-poll.mjs"
+    exe_remote "chmod +x $scripts_dir/linear-poll.mjs"
+
+    local label_map_json="{"
+    IFS=',' read -ra projs <<< "$PROJECTS"
+    local first=true
+    for proj in "${projs[@]}"; do
+      proj=$(echo "$proj" | xargs)
+      if $first; then first=false; else label_map_json+=","; fi
+      label_map_json+="\"$proj\":\"$proj\""
+    done
+    label_map_json+="}"
+
+    ssh "$EXE_HOST" "cat > $scripts_dir/.env" <<EOF
+LINEAR_TOKEN=$LINEAR_API_KEY
+LINEAR_CLI=$EXE_HOME/bin/linear
+TY_PATH=$EXE_HOME/.local/bin/ty
+LABEL_PROJECT_MAP=$label_map_json
+DEFAULT_PROJECT=$(echo "$PROJECTS" | cut -d',' -f1 | xargs)
+EOF
+    ok "Linear poll script installed"
+
+    local cron_line_linear="*/2 * * * * export PATH=$EXE_HOME/.local/bin:$EXE_HOME/bin:\$PATH && node $scripts_dir/linear-poll.mjs >> $scripts_dir/linear-poll.log 2>&1"
+    if exe_remote "crontab -l 2>/dev/null" | grep -q "linear-poll.mjs"; then
+      ok "Linear cron job already exists"
+    else
+      exe_remote "(crontab -l 2>/dev/null; echo '$cron_line_linear') | crontab -"
+      ok "Linear cron job installed"
+    fi
+  fi
+
+  # Start TaskYou daemon
+  log "Starting TaskYou daemon"
+  if exe_remote_with_path "ty daemon status" 2>/dev/null | grep -q "running"; then
+    ok "Daemon already running"
+  else
+    exe_remote "nohup $EXE_HOME/.local/bin/ty daemon --dangerous > /tmp/ty-daemon.log 2>&1 &"
+    sleep 2
+    if exe_remote_with_path "ty daemon status" 2>/dev/null | grep -q "running"; then
+      ok "Daemon started"
+    else
+      warn "Daemon may not have started. Check with: ssh $EXE_HOST 'ty daemon status'"
+    fi
+  fi
+
+  log "exe.dev deployment complete!"
+  echo ""
+  echo "  Landing page:  https://${EXE_DEV_VM_NAME}.exe.xyz"
+  echo "  GM terminal:   https://${EXE_DEV_VM_NAME}.xterm.exe.xyz/?name=gm"
+  echo "  Shell:         https://${EXE_DEV_VM_NAME}.xterm.exe.xyz/"
+  echo ""
+  echo "  Share access:  ssh exe.dev share add $EXE_DEV_VM_NAME user@example.com"
+  echo ""
+}
+
 # ── Manual steps checklist ───────────────────────────────────────────────────
 
 print_checklist() {
@@ -564,6 +912,9 @@ case "$MODE" in
   server)
     setup_server
     print_checklist
+    ;;
+  exe)
+    setup_exe_dev
     ;;
   all)
     setup_local

--- a/templates/exe-dev/CLAUDE.md.tmpl
+++ b/templates/exe-dev/CLAUDE.md.tmpl
@@ -1,0 +1,183 @@
+# {{PROJECT_DISPLAY_NAME}} General Manager
+
+You are the General Manager for {{PROJECT_DISPLAY_NAME}}. You manage AI agents on this server. You don't do the work yourself — you create tasks, monitor progress, and handle delivery.
+
+## Your Role
+
+**You are a manager, not a doer.** You do NOT:
+- Write code for {{PROJECT_DISPLAY_NAME}}
+- Make changes to the {{PROJECT_DISPLAY_NAME}} codebase
+- Execute tasks yourself
+
+**You DO:**
+- Break down {{OWNER_NAME}}'s ideas into clear, actionable tasks
+- Create tasks via TaskYou
+- Monitor task progress and report status
+- Reprioritize and adjust tasks based on new directives
+- Review agent output and flag issues
+- Think strategically about the projects and business operations
+
+## Running Commands
+
+You are running directly on the server. Use `ty` commands directly — no SSH wrappers needed.
+
+```bash
+# TaskYou commands
+ty list
+ty create "My task" --project marketing --type draft --body "Details"
+ty board
+ty execute <task-id>
+ty output <task-id>
+```
+
+## Projects
+
+{{PROJECTS_TABLE}}
+
+## Task Types
+
+| Type      | Use for                                         |
+|-----------|------------------------------------------------|
+| draft     | Writing polished first drafts                   |
+| research  | Market research, competitor analysis            |
+| outreach  | Sales emails, sequences, cold outreach          |
+| social    | Social media content for any platform           |
+| writing   | General writing (built-in)                      |
+| thinking  | Strategic analysis and planning (built-in)      |
+
+## Server Daemon
+
+The daemon must be running in `--dangerous` mode for agents to work:
+
+```bash
+# Check status
+ty daemon status
+
+# If not running, start it:
+nohup ty daemon --dangerous > /tmp/ty-daemon.log 2>&1 &
+
+# Check logs
+tail -20 /tmp/ty-daemon.log
+
+# Restart (stop then start)
+ty daemon stop
+```
+
+**Common issues:**
+- If tasks go to "blocked" immediately, the daemon likely isn't in `--dangerous` mode or isn't running
+- Stale tmux sessions from old daemons can block new ones — use `ty sessions cleanup` and `tmux kill-server` before restarting
+- Git identity is configured as `{{GIT_NAME}} <{{GIT_EMAIL}}>` — if this gets lost, the daemon can't create worktrees
+
+**Project paths:** Each project is a git repo at `~/projects/<project>/`. Task worktrees live at `~/projects/<project>/.task-worktrees/<task-slug>/`.
+
+## TaskYou Quick Reference
+
+```bash
+ty create "Task title" --project marketing --type draft --body "Detailed description"
+ty list
+ty list --project content
+ty board
+ty execute <task-id>
+ty retry <task-id>
+ty output <task-id>
+ty input <task-id> --key Down
+ty input <task-id> --enter
+ty sessions list
+ty sessions cleanup
+ty close <task-id>
+ty move <task-id> --project sales
+```
+
+## Delivery Workflow
+
+Agents complete work but often can't finish the last mile. The GM handles delivery and handoff to humans.
+
+### When an agent task is done:
+
+1. **Review** the agent's output in the worktree/branch
+2. **Push** the branch to the project's GitHub repo and merge it
+{{#R2}}
+3. **Upload any assets** (images, files) to R2 so they have public download URLs
+{{/R2}}
+{{#LINEAR}}
+4. **Create a Linear issue** (team: {{LINEAR_TEAM_KEY}}, label: "Agent Handoff") with:
+   - Clear description of what was done
+{{#R2}}
+   - **Direct download links** to every asset on R2
+{{/R2}}
+   - **Full copy/content inline** in the issue
+   - **Step-by-step action items** written for non-technical humans
+   - Suggested schedule/timing if relevant
+{{/LINEAR}}
+
+### Handoff principles:
+- **Assume the human is non-technical.**
+{{#R2}}
+- **Every asset must have a clickable download link** (R2 public URL).
+{{/R2}}
+- **All content must be inline** — copy, captions, hashtags, everything needed to execute.
+- **Be specific, not vague.** "Post to Instagram" is bad. "Post to Instagram with this caption and this image" is good.
+
+### Project GitHub Repos
+
+{{GITHUB_REPOS_TABLE}}
+
+{{#LINEAR}}
+### Linear (Human Task Handoff)
+
+All handoff to humans goes through Linear, NOT GitHub Issues.
+
+```
+API key: {{LINEAR_API_KEY}}
+Team ID: {{LINEAR_TEAM_ID}}
+Team key: {{LINEAR_TEAM_KEY}}
+Label "Agent Handoff": {{LINEAR_LABEL_ID}}
+State "Todo": {{LINEAR_STATE_ID}}
+Workspace: {{LINEAR_WORKSPACE_URL}}
+```
+
+### Linear CLI
+
+A `linear` CLI is available for all Linear operations.
+
+```bash
+linear issue create --title "..." --body "..." --label "Agent Handoff" --state Todo
+linear issue list [--limit 10]
+linear issue show {{LINEAR_TEAM_KEY}}-93
+linear comment add {{LINEAR_TEAM_KEY}}-93 "comment body"
+linear comment add {{LINEAR_TEAM_KEY}}-93 "comment body" --as-user
+linear comment list {{LINEAR_TEAM_KEY}}-93
+linear issue list --json
+```
+
+Config: `~/tools/linear-cli/.env`
+{{/LINEAR}}
+
+{{#R2}}
+### Cloudflare R2 (Asset Hosting)
+
+All deliverable assets must be uploaded to R2 for public access.
+
+```
+Bucket: {{R2_BUCKET}}
+Public URL base: {{R2_PUBLIC_URL}}/
+```
+{{/R2}}
+
+{{#LINEAR}}
+## @agent Revision System
+
+Humans can request revisions by commenting `@agent` on a Linear issue. A polling script picks this up automatically every 2 minutes.
+{{/LINEAR}}
+
+## Operating Principles
+
+1. **Clarity over speed** - Write tasks that are unambiguous.
+2. **One outcome per task** - Keep tasks focused.
+3. **Include context** - Give agents the background they need.
+4. **Set acceptance criteria** - Define what "done" looks like.
+5. **Prioritize ruthlessly** - Help {{OWNER_NAME}} focus on what moves the needle.
+
+## About {{PROJECT_DISPLAY_NAME}}
+
+{{PROJECT_DESCRIPTION}}

--- a/templates/exe-dev/board-refresh.tmpl
+++ b/templates/exe-dev/board-refresh.tmpl
@@ -1,0 +1,7 @@
+#!/bin/bash
+export PATH="$HOME/bin:$HOME/.local/bin:$PATH"
+while true; do
+  ty board --json --limit 20 > /var/www/html/board.json.tmp 2>/dev/null && \
+    mv /var/www/html/board.json.tmp /var/www/html/board.json
+  sleep 10
+done

--- a/templates/exe-dev/gm-launcher.tmpl
+++ b/templates/exe-dev/gm-launcher.tmpl
@@ -1,0 +1,2 @@
+#!/bin/bash
+cd /home/exedev/projects/gm && exec claude --dangerously-skip-permissions "$@"

--- a/templates/exe-dev/landing-page.html.tmpl
+++ b/templates/exe-dev/landing-page.html.tmpl
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{PROJECT_DISPLAY_NAME}} GM</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      background: #0f1117;
+      color: #c9d1d9;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      min-height: 100vh;
+    }
+
+    .header {
+      padding: 32px 40px 24px;
+      border-bottom: 1px solid #21262d;
+    }
+    .header h1 {
+      font-size: 24px;
+      font-weight: 600;
+      color: #f0f6fc;
+      margin-bottom: 8px;
+    }
+    .header p {
+      color: #8b949e;
+      font-size: 14px;
+      max-width: 600px;
+      line-height: 1.5;
+    }
+
+    .actions {
+      padding: 24px 40px;
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 20px;
+      border-radius: 8px;
+      font-size: 14px;
+      font-weight: 600;
+      text-decoration: none;
+      border: none;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+    .btn-primary {
+      background: #238636;
+      color: #fff;
+    }
+    .btn-primary:hover { background: #2ea043; }
+    .btn-secondary {
+      background: #21262d;
+      color: #c9d1d9;
+      border: 1px solid #30363d;
+    }
+    .btn-secondary:hover { background: #30363d; }
+
+    .board-section {
+      padding: 24px 40px;
+    }
+    .board-section h2 {
+      font-size: 16px;
+      font-weight: 600;
+      color: #f0f6fc;
+      margin-bottom: 16px;
+    }
+    .board {
+      display: flex;
+      gap: 16px;
+      overflow-x: auto;
+      padding-bottom: 16px;
+    }
+    .column {
+      min-width: 260px;
+      max-width: 300px;
+      flex: 1;
+      background: #161b22;
+      border-radius: 8px;
+      border: 1px solid #21262d;
+    }
+    .column-header {
+      padding: 12px 16px;
+      font-size: 13px;
+      font-weight: 600;
+      color: #8b949e;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      border-bottom: 1px solid #21262d;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .column-header .count {
+      background: #30363d;
+      color: #8b949e;
+      padding: 2px 8px;
+      border-radius: 10px;
+      font-size: 11px;
+    }
+    .column-body {
+      padding: 8px;
+      min-height: 60px;
+    }
+    .card {
+      background: #0d1117;
+      border: 1px solid #21262d;
+      border-radius: 6px;
+      padding: 10px 12px;
+      margin-bottom: 6px;
+      font-size: 13px;
+      line-height: 1.4;
+    }
+    .card .title { color: #f0f6fc; font-weight: 500; }
+    .card .meta {
+      color: #484f58;
+      font-size: 11px;
+      margin-top: 4px;
+    }
+    .card .project {
+      display: inline-block;
+      background: #1f2937;
+      color: #7ee787;
+      padding: 1px 6px;
+      border-radius: 4px;
+      font-size: 11px;
+    }
+    .empty-col {
+      color: #484f58;
+      font-size: 12px;
+      text-align: center;
+      padding: 16px 8px;
+    }
+    .board-error {
+      color: #484f58;
+      font-size: 13px;
+      padding: 20px 0;
+    }
+    .last-updated {
+      color: #484f58;
+      font-size: 11px;
+      margin-top: 8px;
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <h1>{{PROJECT_DISPLAY_NAME}} GM</h1>
+    <p>{{PROJECT_DESCRIPTION}}</p>
+  </div>
+
+  <div class="actions">
+    <a class="btn btn-primary" href="https://{{EXE_DEV_VM_NAME}}.xterm.exe.xyz/?name=gm" target="_blank">Open GM Terminal</a>
+    <a class="btn btn-secondary" href="https://{{EXE_DEV_VM_NAME}}.xterm.exe.xyz/" target="_blank">Open Shell</a>
+  </div>
+
+  <div class="board-section">
+    <h2>Task Board</h2>
+    <div id="board" class="board">
+      <div class="board-error">Loading board...</div>
+    </div>
+    <div id="last-updated" class="last-updated"></div>
+  </div>
+
+  <script>
+    const COLUMNS = ['todo', 'in_progress', 'blocked', 'done'];
+    const LABELS = { todo: 'To Do', in_progress: 'In Progress', blocked: 'Blocked', done: 'Done' };
+
+    function renderBoard(tasks) {
+      const board = document.getElementById('board');
+      if (!tasks || tasks.length === 0) {
+        board.innerHTML = '<div class="board-error">No tasks yet.</div>';
+        return;
+      }
+
+      const grouped = {};
+      COLUMNS.forEach(c => grouped[c] = []);
+      tasks.forEach(t => {
+        const col = grouped[t.status] || grouped['todo'];
+        col.push(t);
+      });
+
+      board.innerHTML = COLUMNS.map(col => {
+        const items = grouped[col];
+        const cards = items.length > 0
+          ? items.map(t =>
+              '<div class="card">' +
+                '<div class="title">' + escapeHtml(t.title || t.name || 'Untitled') + '</div>' +
+                '<div class="meta">' +
+                  (t.project ? '<span class="project">' + escapeHtml(t.project) + '</span> ' : '') +
+                  (t.id ? '#' + t.id : '') +
+                '</div>' +
+              '</div>'
+            ).join('')
+          : '<div class="empty-col">No tasks</div>';
+
+        return '<div class="column">' +
+          '<div class="column-header">' + LABELS[col] + ' <span class="count">' + items.length + '</span></div>' +
+          '<div class="column-body">' + cards + '</div>' +
+        '</div>';
+      }).join('');
+    }
+
+    function escapeHtml(str) {
+      var d = document.createElement('div');
+      d.textContent = str;
+      return d.innerHTML;
+    }
+
+    function updateTimestamp() {
+      document.getElementById('last-updated').textContent = 'Last updated: ' + new Date().toLocaleTimeString();
+    }
+
+    async function fetchBoard() {
+      try {
+        var res = await fetch('/board.json?_=' + Date.now());
+        if (!res.ok) throw new Error('Not found');
+        var data = await res.json();
+        var tasks = Array.isArray(data) ? data : (data.tasks || []);
+        renderBoard(tasks);
+        updateTimestamp();
+      } catch (e) {
+        // Keep existing board content on fetch error, just update timestamp
+        var board = document.getElementById('board');
+        if (board.querySelector('.board-error')) {
+          board.innerHTML = '<div class="board-error">Board data not available yet. Waiting for first refresh...</div>';
+        }
+      }
+    }
+
+    fetchBoard();
+    setInterval(fetchBoard, 10000);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds `exe` mode to `setup.sh` that deploys a GM onto an exe.dev VM
- Creates server-local CLAUDE.md (no SSH wrapping — `ty` runs directly on the VM)
- Sets up static landing page with live kanban board, GM launcher, bashrc auto-launch hook, board refresh daemon, and nginx
- One command: `./setup.sh exe /path/to/project` (requires `EXE_DEV_VM_NAME` in config.env)
- Fully idempotent — safe to re-run

## What gets deployed

| Component | Location on VM |
|-----------|---------------|
| GM project dir | `/home/exedev/projects/gm/` |
| GM CLAUDE.md (server-local) | `/home/exedev/projects/gm/CLAUDE.md` |
| GM launcher | `/home/exedev/bin/gm` |
| Board refresh daemon | `/home/exedev/bin/board-refresh` |
| Landing page | `/var/www/html/index.html` |
| Board JSON | `/var/www/html/board.json` |
| Bashrc hook | appended to `/home/exedev/.bashrc` |
| Crontab | `@reboot board-refresh` |

## New files

- `templates/exe-dev/CLAUDE.md.tmpl` — server-local GM instructions (no SSH wrappers)
- `templates/exe-dev/landing-page.html.tmpl` — static HTML with kanban board polling `/board.json`
- `templates/exe-dev/gm-launcher.tmpl` — `claude --dangerously-skip-permissions` wrapper
- `templates/exe-dev/board-refresh.tmpl` — daemon that writes `ty board --json` every 10s

## Config

New optional variables in `config.example.env`:
```
EXE_DEV_ENABLED="true"
EXE_DEV_VM_NAME="myproject-gm"
```

## Test plan

- [ ] Run `./setup.sh exe /path/to/test-project` with a config.env containing `EXE_DEV_VM_NAME`
- [ ] Verify landing page loads at `https://<vm>.exe.xyz`
- [ ] Verify "Open GM Terminal" button launches Claude via `https://<vm>.xterm.exe.xyz/?name=gm`
- [ ] Verify board.json refreshes every 10s
- [ ] Run setup again to verify idempotency (no duplicate bashrc hooks, cron entries)

Spec: `gms/ds-expansion/specs/exe-dev-gm-deployment.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)