### PR TITLE
Add automatic task tracking and /babysit command

### DIFF
--- a/.claude/commands/doctor.md
+++ b/.claude/commands/doctor.md
@@ -237,6 +237,61 @@ ssh "$SERVER_HOST" 'export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:$PATH" &
 
 ---
 
+### Check 6: GM Templates Up to Date
+
+Check if the GM has the latest commands and template content from the plugin.
+
+**Steps:**
+
+1. Find the plugin's installed template directory:
+```bash
+PLUGIN_DIR=$(python3 -c "import json; d=json.load(open('$HOME/.claude/plugins/installed_plugins.json')); entries=d.get('plugins',{}).get('taskyou-os@taskyou-os',[]); print(entries[0]['installPath'] if entries else '')" 2>/dev/null)
+echo "Plugin dir: $PLUGIN_DIR"
+```
+
+2. List the command templates available in the plugin vs commands installed in the GM:
+```bash
+echo "=== Plugin templates ==="
+ls "$PLUGIN_DIR/templates/commands/" 2>/dev/null | sed 's/.md.tmpl$//'
+
+echo "=== GM commands ==="
+ls "$LOCAL_PROJECT_DIR/.claude/commands/" 2>/dev/null | sed 's/.md$//'
+```
+
+3. **For each command template that does NOT exist in the GM** (new commands):
+   - This is a new command added since the GM was set up
+   - Render it by sourcing the GM's `config.env` and using setup.sh's render function:
+   ```bash
+   source "$CONFIG"
+   cd "$(dirname "$CONFIG")/.."
+   bash -c 'source setup.sh 2>/dev/null; source "'"$CONFIG"'"; render_file "'"$PLUGIN_DIR"'/templates/commands/NEW_CMD.md.tmpl" "/tmp/taskyou-doctor-new-cmd.md"' 2>/dev/null
+   ```
+   If the render_file approach doesn't work, do simple `{{VARIABLE}}` substitution yourself using the config values.
+   - **Show the user what the command does** (read the rendered file and summarize it)
+   - **Ask the user** if they want to add it to their GM
+   - If yes, copy the rendered file to `$LOCAL_PROJECT_DIR/.claude/commands/`
+
+4. **For CLAUDE.md** — check if the plugin's template has new sections the GM is missing:
+   - Read the plugin's `$PLUGIN_DIR/templates/CLAUDE.md.tmpl`
+   - Read the GM's `$LOCAL_PROJECT_DIR/CLAUDE.md`
+   - Compare section headers (`## ` lines) between the template and the GM's file
+   - For each section in the template that does NOT exist in the GM's CLAUDE.md:
+     - Render that section (substitute `{{VARIABLE}}` placeholders using config.env values)
+     - **Show the user** the new section content and where it would logically go
+     - **Ask the user** if they want to add it
+     - If yes, insert it at the appropriate location in the GM's CLAUDE.md
+   - Do NOT touch or overwrite existing sections — only offer to add new ones
+
+5. **For existing commands that differ from the template**: Note which commands have upstream changes available, but do NOT overwrite them. Just inform the user: "The template for /gm-status has been updated. You may want to review the changes."
+
+**Important:** Always ask before modifying any file. Never overwrite a file that the user may have customized.
+
+**If no new templates/sections found:** Report PASS with "GM templates are up to date."
+**If new commands/sections were added:** Report WARN with summary of what was added.
+**If user declined updates:** Report WARN with "Updates available but skipped."
+
+---
+
 ## Summary
 
 After all checks, present a summary table:
@@ -249,6 +304,7 @@ TaskYou-OS Doctor
   Daemon running     PASS/WARN/FAIL
   Daemon mode        PASS/WARN/FAIL
   Executor health    PASS/WARN/FAIL
+  GM templates       PASS/WARN/FAIL
 ─────────────────────────────────
 ```
 

--- a/templates/CLAUDE.md.tmpl
+++ b/templates/CLAUDE.md.tmpl
@@ -275,6 +275,44 @@ Humans can request revisions on agent-delivered work by commenting `@agent` (or 
 4. **Set acceptance criteria** - Define what "done" looks like for each task.
 5. **Prioritize ruthlessly** - Not everything needs to happen now. Help {{OWNER_NAME}} focus on what moves the needle.
 
+## Task Tracking
+
+You are responsible for following up on tasks you execute. This is automatic — {{OWNER_NAME}} should never have to ask "what happened with that task?"
+
+### Automatic monitoring
+
+When you execute a task (`ty execute <id>`):
+
+1. **Add it to your todos** via TodoWrite with the task ID, title, and current status.
+2. **Launch a background monitoring agent** to watch for task events. The agent should:
+   - Watch the server's notification stream: `./bin/ssh-remote "tail -n 0 -f {{SERVER_HOME}}/notifications.jsonl"`
+   - The server hooks automatically write to this file when tasks complete or get blocked
+   - When a line appears matching a tracked task ID, return immediately with the event details
+   - Time out after 20 minutes and return (you can re-launch if needed)
+   - One background agent can watch for ALL tracked tasks — no need for one per task
+3. **When the background agent returns with an event**, update your todo and inform {{OWNER_NAME}}:
+   - **Completed**: Briefly note it finished, offer to show output (`ty output <id>`). Mark todo done.
+   - **Blocked**: Note what's blocking it, suggest next steps (retry, send input, review).
+   - Then re-launch the background agent if there are still tasks being tracked.
+
+### Be non-disruptive
+
+When a background agent notifies you of a task update, be smart about surfacing it:
+- If {{OWNER_NAME}} is mid-thought or you're in the middle of a complex discussion, hold the update and surface it at a natural pause.
+- Keep updates brief — one line is ideal. "Task #12 (competitor research) just finished. Want to see the output?"
+- Don't pile up multiple updates at once. Space them out if several tasks complete simultaneously.
+- If a task is blocked and you can resolve it yourself (e.g. permission prompt → `ty input <id> --enter`), do so silently and only mention it if it keeps failing.
+
+### What NOT to track
+
+- Tasks {{OWNER_NAME}} explicitly says don't need monitoring ("don't worry about that one", "I'll check on it later")
+- Tasks you create but don't execute yet — track them when they're actually running
+- If {{OWNER_NAME}} says to stop tracking something, respect that immediately
+
+### Manual check
+
+{{OWNER_NAME}} can use `/babysit` for an immediate status check on all tracked tasks without waiting for background agents.
+
 ## Advanced: Raw SSH Access
 
 The `./bin/ty-remote` and `./bin/ssh-remote` wrappers handle SSH connection and PATH setup automatically. If you need to run commands manually (e.g. for debugging), the underlying SSH pattern is:

--- a/templates/commands/babysit.md.tmpl
+++ b/templates/commands/babysit.md.tmpl
@@ -1,0 +1,26 @@
+Check on all tasks you're currently tracking. Use this for an immediate status update.
+
+## Steps
+
+1. **Check for recent events** from the server notification stream:
+```bash
+./bin/ssh-remote "tail -20 {{SERVER_HOME}}/notifications.jsonl" 2>/dev/null
+```
+
+2. **Get current task statuses:**
+```bash
+./bin/ty-remote list
+```
+
+3. **Compare against your todos** — identify any status changes since last check.
+
+4. **For each tracked task, report:**
+   - **Completed**: Mark todo done. Offer to show output (`./bin/ty-remote output <id>`).
+   - **Blocked**: Explain what's blocking it. Suggest next steps (retry, send input, review output).
+   - **Still processing**: Note it's still running — no action needed unless it's been unusually long.
+
+5. **Re-launch the background notification watcher** if there are tasks still in progress and no background agent is currently watching.
+
+6. **If all tracked tasks are done**, let {{OWNER_NAME}} know there's nothing left to monitor.
+
+Keep updates brief — one line per task.


### PR DESCRIPTION
## Summary

- **Automatic task tracking**: GMs now automatically monitor tasks they execute — adds them to todos and launches a background agent that watches the server's `notifications.jsonl` stream for completion/blocked events. Updates are surfaced non-disruptively at natural conversation pauses.
- **New `/babysit` command**: Immediate manual status check on all tracked tasks.
- **`/doctor` Check 6 (GM Templates)**: Detects new commands and CLAUDE.md sections available from the plugin and offers to add them to existing GM installations. Asks before modifying anything — never overwrites customized files.

## Test plan

- [ ] Run `/doctor` on an existing GM — verify it detects the missing `/babysit` command and "Task Tracking" CLAUDE.md section
- [ ] Accept the updates and verify files are added correctly
- [ ] Launch a new GM with `/launch` and verify `/babysit` is rendered and Task Tracking section is in CLAUDE.md
- [ ] Execute a task in a GM and verify the GM automatically adds it to todos and starts background monitoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)