### PR TITLE
Fix task.started hook: derive WORKTREE_PATH fallback

### DIFF
--- a/templates/hooks/task.started.tmpl
+++ b/templates/hooks/task.started.tmpl
@@ -6,6 +6,15 @@
 CLAUDE_JSON="$HOME/.claude.json"
 WORKTREE_PATH="${WORKTREE_PATH:-}"
 
+# Fallback: if WORKTREE_PATH not provided, find it from TASK_ID + TASK_PROJECT
+if [[ -z "$WORKTREE_PATH" && -n "${TASK_ID:-}" && -n "${TASK_PROJECT:-}" ]]; then
+  DATA_DIR="$HOME/.local/share/task/${TASK_PROJECT}"
+  # Find the worktree directory matching this task ID
+  for dir in "$DATA_DIR"/.task-worktrees/"${TASK_ID}"-*/; do
+    [[ -d "$dir" ]] && WORKTREE_PATH="${dir%/}" && break
+  done
+fi
+
 [[ -z "$WORKTREE_PATH" ]] && exit 0
 [[ ! -f "$CLAUDE_JSON" ]] && exit 0
 


### PR DESCRIPTION
## Summary
- The `task.started` hook expected `WORKTREE_PATH` as an env var, but TaskYou hooks only pass `TASK_ID`, `TASK_TITLE`, `TASK_PROJECT`, etc. — `WORKTREE_PATH` is a runtime env var, not a hook env var
- The hook silently exited on every task, leaving worktree directories untrusted and agents stuck on Claude's interactive "trust this folder" prompt
- Added a fallback that derives the worktree path by globbing `~/.local/share/task/<project>/.task-worktrees/<id>-*/` from the available hook variables

Companion fix in TaskYou: https://github.com/bborn/taskyou/pull/506 (passes `WORKTREE_PATH` to hooks natively). This fallback covers older TaskYou versions.

## Test plan
- [ ] Fresh install: create a task, verify the trust prompt no longer appears
- [ ] Verify `~/.claude.json` contains the worktree path with `hasTrustDialogAccepted: true` after task starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)