### PR TITLE
Fix $HOME expansion and exe.dev SSH check in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -490,7 +490,7 @@ setup_server() {
     # The task.started hook handles worktree paths dynamically.
     ssh "$SERVER_HOST" "python3 -c \"
 import json
-cf = '$HOME/.claude.json'
+cf = '$SERVER_HOME/.claude.json'
 with open(cf) as f: data = json.load(f)
 p = data.setdefault('projects', {}).setdefault('$repo_path', {})
 p['hasTrustDialogAccepted'] = True
@@ -634,7 +634,7 @@ setup_exe_dev() {
   log "Deploying GM to exe.dev VM: $EXE_DEV_VM_NAME"
 
   # Check SSH access to exe.dev management
-  if ! ssh -o ConnectTimeout=5 -o BatchMode=yes exe.dev "echo ok" >/dev/null 2>&1; then
+  if ! ssh -o ConnectTimeout=5 -o BatchMode=yes exe.dev </dev/null >/dev/null 2>&1; then
     echo "Error: Cannot SSH to exe.dev"
     echo "Make sure your SSH key is registered with exe.dev."
     echo "Visit https://exe.dev to set up your account and SSH key."
@@ -716,7 +716,7 @@ setup_exe_dev() {
     # Pre-accept Claude trust
     ssh "$EXE_HOST" "python3 -c \"
 import json
-cf = '$HOME/.claude.json'
+cf = '$EXE_HOME/.claude.json'
 with open(cf) as f: data = json.load(f)
 p = data.setdefault('projects', {}).setdefault('$repo_path', {})
 p['hasTrustDialogAccepted'] = True
@@ -753,7 +753,7 @@ with open(cf, 'w') as f: json.dump(data, f, indent=2)
   # Pre-accept Claude trust for GM directory
   ssh "$EXE_HOST" "python3 -c \"
 import json
-cf = '$HOME/.claude.json'
+cf = '$EXE_HOME/.claude.json'
 with open(cf) as f: data = json.load(f)
 p = data.setdefault('projects', {}).setdefault('$EXE_HOME/projects/gm', {})
 p['hasTrustDialogAccepted'] = True


### PR DESCRIPTION
## Summary
- **`$HOME` expansion bug**: Three places in `setup.sh` used `$HOME` inside double-quoted SSH commands to set Claude trust in `~/.claude.json`. Since `$HOME` expands locally, it resolved to `/Users/bruno` instead of the remote server's home (e.g. `/home/exedev`). Fixed by using `$SERVER_HOME` / `$EXE_HOME` which already hold the correct remote paths.
- **exe.dev SSH check bug**: The connectivity check sent `"echo ok"` as a remote command, but exe.dev has a custom REPL that doesn't understand shell commands. Fixed by redirecting stdin from `/dev/null` so the REPL gets EOF and exits cleanly.

## Test plan
- [ ] Run `./setup.sh server <project-dir>` and verify Claude trust is written to the correct remote path
- [ ] Run `./setup.sh exe <project-dir>` and verify the exe.dev SSH check passes
- [ ] Verify `.claude.json` on the remote server has correct project paths after setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)