### PR TITLE
Publish the channel (plugin 1.3.0) + smooth existing-GM onboarding

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "taskyou-os",
       "description": "Launch and manage AI agent teams on remote servers. Interactive setup walks you through everything — server provisioning, configuration, and deployment.",
-      "version": "1.0.0",
+      "version": "1.3.0",
       "author": {
         "name": "TaskYou"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "taskyou-os",
   "description": "Launch and manage AI agent teams on remote servers. Interactive setup walks you through everything — server provisioning, configuration, and deployment.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "TaskYou"
   },

--- a/.claude/commands/gm-doctor.md
+++ b/.claude/commands/gm-doctor.md
@@ -362,15 +362,22 @@ test -d "$LOCAL_PROJECT_DIR/channel/node_modules" && echo "DEPS_INSTALLED" || ec
 
 4. **If channel exists, check for drift** — compare deployed channel against the plugin template (same approach as nono drift detection in Check 9). If the template is newer, update the deployed file and report WARN.
 
-5. **Check the shell alias** includes `--dangerously-load-development-channels server:taskyou`:
+5. **Check the shell alias** includes `--dangerously-load-development-channels server:taskyou`. This is the one step that doesn't self-heal, so make it as close to one-click as possible:
    ```bash
-   grep "$GM_ALIAS" ~/.zshrc 2>/dev/null || grep "$GM_ALIAS" ~/.bashrc 2>/dev/null
+   # Find which rc file defines the alias
+   for rc in ~/.zshrc ~/.bashrc; do grep -q "alias $GM_ALIAS=" "$rc" 2>/dev/null && echo "$rc"; done
    ```
-   - If the alias exists but doesn't include `--dangerously-load-development-channels server:taskyou`, report WARN and show the user the updated alias line they should use:
+   - If the alias already includes the flag, report PASS.
+   - If the alias exists but is missing the flag: build the corrected line (the existing alias body + ` --dangerously-load-development-channels server:taskyou` appended after `claude`), then **offer to update it in place** rather than making the user hand-edit:
+     > "Your `$GM_ALIAS` alias needs the channel flag to receive push notifications. Want me to update it in `<rc file>`? (I'll back the file up first.)"
+
+     On yes, replace just that alias line in the rc file (back up to `<rc>.bak` first), then tell the user to run `source <rc file>` and restart the GM for it to take effect. On no, show them the exact line to paste:
      ```
      alias <GM_ALIAS>='cd <LOCAL_PROJECT_DIR> && CLAUDE_CONFIG_DIR=<CONFIG_DIR> claude --dangerously-load-development-channels server:taskyou'
      ```
-   - If the alias already includes the flag, report PASS.
+   - If no alias is found at all, show the full line above and point them at the README "Updating" section.
+
+   Always end this step by reminding the user: **the channel only loads at launch, so restart the GM after any alias change.**
 
 6. **Check the CLAUDE.md** has the channel-based monitoring section (not the old background-agent approach):
    ```bash

--- a/README.md
+++ b/README.md
@@ -125,10 +125,13 @@ Run `/taskyou-os:doctor` from any directory. It checks and updates everything au
 4. **Executor health** — confirms every active task has a running executor pane, recovers orphaned tasks
 5. **Command migration** — removes old local command files that shadow newer plugin-delivered versions
 6. **CLAUDE.md drift** — detects new sections in the plugin template and offers to add them to your GM
-7. **Security audit** — runs the server-side credential and permissions check
-8. **Credential isolation** — verifies nono sandbox setup and detects template drift
+7. **Task event channel** — deploys the push-notification channel to a GM that predates it (renders `channel/`, installs deps, writes `.mcp.json`) and offers to add the channel flag to your launch alias
+8. **Security audit** — runs the server-side credential and permissions check
+9. **Credential isolation** — verifies nono sandbox setup and detects template drift
 
 If `/doctor` finds issues, it fixes what it can and tells you what to do for the rest.
+
+> **Enabling push notifications on an existing GM:** task events now arrive automatically as `<channel>` messages instead of needing a polling agent. Update the plugin, then run `/taskyou-os:doctor` — it deploys the channel and offers to add the required flag to your launch alias. After the alias change, **restart the GM** so the channel loads. (Channels are in research preview: they need Claude Code 2.1.80+ and a claude.ai login.)
 
 ### Update the Server
 


### PR DESCRIPTION
## Summary

The task-event channel shipped in #28/#31/#34 but was **never published**: `plugin.json` was still `1.2.0` and `marketplace.json` stale at `1.0.0`, so neither `/launch` (new GMs) nor `/gm-doctor` (existing GMs) could deliver it. This releases it and smooths the existing-GM upgrade.

## Changes

- **Publish:** bump `plugin.json` `1.2.0 → 1.3.0`, sync `marketplace.json` `1.0.0 → 1.3.0` (the two had drifted apart).
- **Smooth the one manual step** — `/gm-doctor` Check 7 now *offers to update the launch alias in place* (with a `.bak` backup) instead of making the user hand-edit `~/.zshrc`, and always reminds them to **restart the GM** (the channel loads at launch).
- **Docs** — README "Updating" gains a "push notifications on an existing GM" note and the channel entry in the `/doctor` checklist (was stale at 8 checks).

## Onboarding after this releases

- **New GMs** (`/launch`) → channel rendered automatically + alias printed with the flag. Effortless.
- **Existing GMs** → `update plugin → /gm-doctor → approve alias update → restart`. `gm-doctor` deploys the channel files; the alias+restart is the only manual bit (unavoidable while channels are research-preview — the `--dangerously` flag is required until they GA).

## Note

This bumps the version in-repo; the actual marketplace release (tag/publish, if your flow needs one beyond merging to `main`) is a maintainer step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
